### PR TITLE
Create markdown chapter on genomic data privacy concerns

### DIFF
--- a/genomic_privacy_concerns.md
+++ b/genomic_privacy_concerns.md
@@ -1,0 +1,111 @@
+```markdown
+# The Genome's Ledger: Balancing Discovery and Discretion in an Age of Unprecedented Genetic Insight
+
+The dawn of widespread genomic sequencing has unlocked a new frontier in understanding human health, promising personalized medicine, novel therapies, and a deeper comprehension of life itself. Companies and research institutions are rapidly accumulating vast datasets of genetic information—veritable goldmines for innovation. However, this explosion of data, akin to a detailed ledger of our biological selves, carries an inherent sensitivity. As we decode the blueprint of life at an accelerating pace, the imperative to safeguard this profoundly personal information has never been more critical. This isn't just about abstract data points; it's about individual dignity, the potential for discrimination, and maintaining societal trust in the very institutions driving progress.
+
+This chapter delves into the nuanced landscape of privacy concerns surrounding genomic datasets. We particularly focus on how allele frequency analysis—even on aggregated data—can become a vector for privacy risk. We will explore the specific factors that amplify these risks and spotlight diseases and conditions where the need for heightened vigilance is not just advisable, but essential for ethical and secure innovation.
+
+## The Double-Edged Sword: Why Genomic Data Is Uniquely Sensitive
+
+Genomic data is unlike other forms of health information. It is:
+
+*   **Inherently Identifiable:** Our DNA is unique (except for identical twins). Even "anonymized" or "de-identified" data can potentially be re-identified. The Electronic Frontier Foundation (EFF) underscores that genetic information cannot be truly anonymized in the same robust manner as other data types [^1^].
+*   **Predictive & Familial:** It can reveal predispositions to future health conditions not only for an individual but also for their biological relatives. This interconnectedness raises complex ethical questions about consent, disclosure, and the "right not to know," issues also highlighted by the EFF in discussions around familial DNA searches and their implications [^1^].
+*   **Immutable:** Unlike a compromised password, an individual cannot change their genome. This permanence makes genetic data breaches, such as the one experienced by 23andMe through credential stuffing and subsequent data scraping [^3^], particularly consequential and long-lasting in their impact [^2^].
+
+Allele frequency analysis, which examines the prevalence of specific gene variants (alleles) within a population, is a cornerstone of genetic research. While often performed on aggregated (pooled) data with the intent of protecting individual identities, certain conditions and contexts can render even this approach surprisingly revealing, punching holes in the veil of aggregation.
+
+## Key Factors Dialing Up the Privacy Thermostat
+
+Several critical factors can significantly increase the sensitivity of aggregated allele frequency data, demanding more sophisticated and robust privacy considerations:
+
+### 1. Rare Diseases or Variants: The Needle in the Haystack
+When a disease is caused by rare genetic variants (e.g., allele frequencies <1%), its presence in aggregated data—especially from smaller or demographically distinct datasets—can inadvertently narrow down the pool of potential individuals. If a rare variant is detected within a dataset from a small, geographically or genetically isolated community, the path to re-identification becomes alarmingly short, particularly when cross-referenced with other publicly or privately available information.
+
+### 2. High Penetrance and Actionable Conditions: When Genes Point to Intervention
+Alleles with high penetrance confer a strong likelihood of an individual developing a specific condition. If these conditions are also "actionable"—meaning significant medical interventions, such as prophylactic surgery or specific drug regimens, are recommended upon discovery—the stakes are immediately raised. Knowledge of such alleles in an aggregated dataset, if traceable back to individuals or small groups, could have profound, life-altering implications. These include risks of insurance or employment discrimination, despite legal safeguards like the Genetic Information Nondiscrimination Act (GINA) of 2008. GINA offers foundational protection in the U.S. against genetic discrimination in health insurance and employment, but its scope has recognized limitations, particularly concerning life insurance, disability insurance, or long-term care insurance [^1^][^5^].
+
+### 3. Stigmatized or Socially Sensitive Conditions: The Weight of Disclosure
+For diseases associated with social stigma (e.g., certain mental health disorders, genetic predispositions to infectious diseases like HIV), the privacy risks are magnified. Allele frequency data that could even hint at the prevalence of such conditions within identifiable populations can expose these groups to discrimination, marginalization, or undue social scrutiny. The unique cybersecurity challenges of protecting such deeply sensitive data are immense, as a breach could have devastating and far-reaching personal consequences [^2^].
+
+### 4. Population-Specific Variants: The Perils of Genetic Ancestry
+Allele frequencies can vary significantly across different ethnic or geographic populations. When datasets include underrepresented groups or those with unique genetic markers, aggregated data can inadvertently highlight these distinctions. This can increase the risk of group-level stigmatization or even re-identification if combined with demographic or geographic metadata. Incidents like the 23andMe data breach, where attackers reportedly targeted and scraped data of users with specific ancestries by exploiting features related to relative matching, underscore this acute vulnerability [^3^].
+
+### 5. Data Aggregation Context: Size, Specificity, and Linkability Matter
+The source, granularity, and composition of aggregated data are crucial. Data from small, geographically isolated populations, or cohorts specifically selected for rare diseases, are inherently more sensitive. In such cases, even anonymized allele frequencies might be de-anonymized with surprisingly little additional information, effectively turning aggregated statistics back into individual (or small group) identifiers. The potential for linkage with external datasets further amplifies this risk.
+
+## Spotlight on High-Risk Domains: Diseases Demanding Enhanced Privacy
+
+Based on these factors, several categories of diseases and conditions require particularly stringent privacy protections when their associated allele frequencies are analyzed, even in aggregated form:
+
+### Hereditary Cancer Syndromes
+*   **Examples:** BRCA1/BRCA2 mutations (hereditary breast and ovarian cancer), Lynch syndrome (colorectal and other cancers).
+*   **Sensitivity Drivers:** These mutations are often rare, highly penetrant, and directly actionable (e.g., prophylactic surgeries, targeted therapies). Aggregated data showing prevalence in specific, smaller populations could risk exposing carrier status, leading to potential insurance or employment discrimination. While GINA provides a baseline, its protections are not all-encompassing, especially for ancillary insurance products [^1^][^5^].
+*   **Privacy Imperative:** Necessitates rigorous anonymization beyond simple hashing, consideration of advanced techniques like differential privacy, and tightly controlled, tiered access to datasets. Data use agreements must be explicit and enforceable, preventing linkage with phenotypic or demographic information without further consent or ethical approval.
+
+### Rare Monogenic Disorders
+*   **Examples:** Cystic fibrosis (CFTR mutations), Huntington’s disease (HTT gene), Spinal Muscular Atrophy (SMA).
+*   **Sensitivity Drivers:** Caused by rare, often highly penetrant mutations. Allele frequency data, particularly from smaller cohorts or specific communities, could allow inference of carrier status or disease prevalence, especially for recessive conditions. The potential for re-identification or community-level anxiety and stigmatization is significant. The immutable nature of this genetic information means a breach has lifelong consequences for individuals and their families [^2^].
+*   **Privacy Imperative:** Encourages aggregation at much larger scales, robust and secure data-sharing protocols (e.g., federated analysis), and extreme caution against publishing fine-grained, population-specific frequencies unless a compelling public health justification exists and risks are explicitly managed.
+
+### Neurodegenerative Diseases
+*   **Examples:** Alzheimer’s disease (APOE ε4 allele), Huntington’s disease, familial Parkinson’s disease (e.g., LRRK2 mutations).
+*   **Sensitivity Drivers:** Many of these conditions have late onset, and knowledge of risk alleles can cause significant psychological distress or lead to discrimination (e.g., in employment or long-term care insurance, areas where GINA's protections are notably weaker [^1^][^5^]). Certain risk alleles (like some LRRK2 variants) are more common in specific populations (e.g., Ashkenazi Jewish, North African), increasing re-identification risks in datasets with ethnic diversity – a risk starkly highlighted by targeted data scraping incidents like the one affecting 23andMe [^3^].
+*   **Privacy Imperative:** Calls for exploring and implementing cryptographic methods (like secure multi-party computation for analysis without data pooling), minimizing access to raw or pseudonymous frequency data, and mandating strong, independent ethical oversight for any research use.
+
+### Mental Health Disorders
+*   **Examples:** Schizophrenia (associated with multiple rare copy number variants), bipolar disorder, major depressive disorder.
+*   **Sensitivity Drivers:** Genetic links to mental health conditions are often highly stigmatized. Aggregated data that reveals higher allele frequencies for associated variants in specific, identifiable populations could inadvertently lead to social, cultural, or economic discrimination against those groups. The Health Insurance Portability and Accountability Act (HIPAA) provides privacy rules for health information, but its application and enforcement concerning large-scale research databases and the nuances of genetic de-identification can be complex. HIPAA's safe harbor de-identification method may not be sufficient for genetic data, and its expert determination method requires careful consideration [^1^][^4^].
+*   **Privacy Imperative:** Demands state-of-the-art anonymization techniques (potentially including synthetic data generation for some queries), strict ethical review protocols for data sharing, and public reporting strategies that conscientiously avoid granular, population-specific details that could be misused or misinterpreted.
+
+### Pharmacogenomic Variants
+*   **Examples:** HLA-B*57:01 (associated with abacavir hypersensitivity in HIV treatment), CYP2C19 variants (affecting clopidogrel and other drug metabolism), TPMT variants (thiopurine drug toxicity).
+*   **Sensitivity Drivers:** These variants directly influence treatment decisions and can indirectly reveal underlying health conditions (e.g., HIV status if HLA-B*57:01 frequency is studied in a particular group, or propensity for certain adverse drug reactions). Rare alleles in specific populations again increase privacy risks if data is not handled with extreme care, potentially exposing individuals to unwanted inferences about their health or medication needs.
+*   **Privacy Imperative:** Requires strictly controlled access to pharmacogenomic databases, potentially using role-based access and query logs. Aggregation should occur at a level that robustly prevents the identification of specific treatment cohorts or patient groups.
+
+### Ethnic-Specific Genetic Disorders
+*   **Examples:** Sickle cell anemia (HBB gene, more prevalent in individuals of African ancestry), Tay-Sachs disease (HEXA mutations, more prevalent in Ashkenazi Jewish populations), Beta-thalassemia (more prevalent in Mediterranean populations).
+*   **Sensitivity Drivers:** Allele frequencies are, by definition, strongly tied to specific ethnic groups. Publishing such frequencies, especially for smaller or more vulnerable populations, can lead to group-level stigmatization, discrimination, or re-identification, particularly if datasets are linked with geographic or ethnic metadata. The targeting of specific ethnic groups in data breaches (e.g., the 23andMe incident involving data relevant to Ashkenazi Jewish ancestry) is a stark and actionable warning [^3^].
+*   **Privacy Imperative:** Advises strongly against publishing allele frequencies explicitly stratified by small or vulnerable ethnic groups without compelling justification, community consultation, and the implementation of strong safeguards like differential privacy. Emphasis should be on equitable benefit sharing and preventing data misuse.
+
+## Summary Table: High-Sensitivity Genome Data & Privacy Needs
+
+| Category                    | Disease Examples                                                      | Reasons for Sensitivity                                                                                                | Key Privacy Needs                                                                                                |
+| :-------------------------- | :-------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
+| **Hereditary Cancer Syndromes** | BRCA1/BRCA2 (breast/ovarian cancer), Lynch syndrome (colorectal cancer) | Rare, highly penetrant mutations; actionable (e.g., surgeries); risk of re-identification, insurance/employment discrimination (GINA limitations [^1^][^5^]) | Strict anonymization (beyond hashing), differential privacy, restricted tiered access, robust data use agreements, ethical oversight. |
+| **Rare Monogenic Disorders**  | Cystic fibrosis, Huntington’s disease, Spinal Muscular Atrophy (SMA)    | Rare, highly penetrant mutations; carrier status inference in small cohorts; re-identification risk in communities. Immutable data [^2^]. | Very large-scale aggregation, secure federated analysis, avoid fine-grained population-specific frequency publication, community engagement. |
+| **Neurodegenerative Diseases**| Alzheimer’s (APOE ε4), Huntington’s, Parkinson’s (LRRK2 mutations)    | Often late-onset; high penetrance for some variants; psychological harm, discrimination (GINA limitations for long-term care insurance [^1^][^5^]); population-specific variant risks (e.g. 23andMe incident [^3^]). | Cryptographic methods (e.g., secure multi-party computation), minimized raw data access, strong independent ethical oversight.     |
+| **Mental Health Disorders**   | Schizophrenia, Bipolar disorder, Major Depressive Disorder            | Highly stigmatized conditions; population-specific allele frequencies could lead to group discrimination or profiling. HIPAA complexities & de-identification challenges [^1^][^4^]. | Advanced anonymization (e.g., synthetic data), strict ethical review, careful public reporting, community consultation.   |
+| **Pharmacogenomic Variants**  | HLA-B*57:01 (HIV treatment), CYP2C19 variants (drug metabolism)        | Can indirectly reveal health status (e.g., HIV); rare alleles in specific populations; direct treatment implications; adverse reaction predispositions.   | Controlled role-based access, query logs, robust aggregation levels preventing cohort identification.            |
+| **Ethnic-Specific Disorders** | Sickle cell anemia, Tay-Sachs disease, Beta-thalassemia               | Allele frequencies strongly linked to specific ethnic groups; risk of group stigmatization or re-identification (e.g. 23andMe incident [^3^]). | Avoid stratification by small/vulnerable ethnic groups without clear justification & community consent; differential privacy; equitable benefit focus. |
+
+## Navigating the Path Forward: Privacy-Enhancing Strategies for Responsible Innovation
+
+Mitigating these risks is not about halting scientific progress, but about architecting a future where innovation and privacy are not trade-offs but synergistic goals. Several strategies are crucial:
+
+*   **Privacy-Enhancing Technologies (PETs):**
+    *   **Differential Privacy:** Mathematically ensuring privacy by adding calibrated noise to query results or datasets, making it extremely difficult to determine if an individual's data is part of a dataset while preserving aggregate analytical value.
+    *   **Secure Computation Techniques:** Employing methods like homomorphic encryption (computation on encrypted data) or secure multi-party computation (where multiple parties can jointly compute a function over their inputs while keeping those inputs private).
+    *   **Federated Learning:** Training machine learning models across multiple decentralized devices or servers holding local data samples, without exchanging the raw data itself.
+    *   **Synthetic Data Generation:** Creating artificial datasets that mimic the statistical properties of the original sensitive data but do not contain real individual records.
+
+*   **Robust Governance and Ethical Frameworks:**
+    *   **Data Aggregation & Generalization:** Carefully pooling data from larger, more diverse populations to dilute the impact of rare variants and reduce identifiability. This includes avoiding overly granular reporting that could inadvertently expose small groups.
+    *   **Tiered Access & Strong Controls:** Implementing granular access controls, multi-factor authentication, and comprehensive audit logs. Data use agreements (DUAs) must be specific, enforceable, and reviewed regularly.
+    *   **Independent Ethical Oversight:** Establishing and empowering independent ethics review boards (IRBs) or ethics committees with expertise in genomics, privacy, and societal implications to review data access requests and research protocols.
+    *   **Legal & Regulatory Adherence (and Advocacy):** Complying with existing frameworks like GDPR in Europe and HIPAA in the U.S. [^4^], while also actively recognizing and advocating for updates to address the limitations of laws like GINA, especially concerning genetic data's unique properties [^1^][^5^].
+    *   **Transparency & Dynamic Consent:** Ensuring that informed consent processes are clear, understandable, and provide individuals with ongoing control over how their data is used. This may involve models of dynamic consent where preferences can be updated over time.
+    *   **International Standards & Collaboration:** Supporting and adopting frameworks from organizations like the Global Alliance for Genomics and Health (GA4GH), which develops standards and policy tools to enable responsible and secure genomic data sharing globally [^6^].
+
+The journey into our collective genomic landscape is one of immense promise, holding keys to unlocking unprecedented medical breakthroughs. However, to realize its full potential for human health, we must navigate it with a profound and unwavering respect for individual privacy and autonomy. By deeply understanding the specific factors and conditions that heighten risk, and by proactively architecting and implementing sophisticated privacy-enhancing technologies and rigorous ethical frameworks, we can build a future where genomic discovery and individual discretion are not mutually exclusive, but mutually reinforcing. The ledger of the genome can then be read not as a list of vulnerabilities, but as a testament to our collective ability to innovate responsibly and equitably.
+
+---
+## References
+
+[^1^]: Electronic Frontier Foundation. "Genetic Information Privacy." (Content accessed reflects general EFF positions and analyses on genetic privacy, GINA, and HIPAA, often drawing from comprehensive but potentially older foundational documents alongside recent blog posts and updates available through late 2023/early 2024).
+[^2^]: ISC2 Insights. "The Unique Cybersecurity Challenges of Genetic Data." (Blog Post, November 2023). Provides perspective on the distinct security risks of genomic information.
+[^3^]: Based on widespread media reporting and analysis of the 23andMe data breach (late 2023), including summaries from sources like Wired (though direct article access may be paywalled/blocked for automated tools, the event's details are public knowledge) and the Electronic Frontier Foundation's blog (e.g., "What to Do If You're Concerned About the 23andMe Breach," October 20, 2023). The breach highlighted risks of credential stuffing and subsequent data scraping, with specific reports of attackers targeting ancestral data.
+[^4^]: General understanding of the Health Insurance Portability and Accountability Act (HIPAA), its scope, Privacy Rule, Security Rule, and limitations, particularly concerning de-identification of genetic data and its application to large research databases. Information synthesized from various public resources including government sites (HHS.gov) and analyses by privacy advocacy groups like EFF.
+[^5^]: National Human Genome Research Institute (NHGRI). General information from NHGRI/NIH resources (genome.gov) discussing the Genetic Information Nondiscrimination Act (GINA), its protections, and its recognized limitations (e.g., not covering life, disability, or long-term care insurance). While specific deep-linked pages provided in the initial prompt were not always resolvable, the core tenets of GINA are well-documented by NHGRI.
+[^6^]: Global Alliance for Genomics and Health (GA4GH). Information based on GA4GH's public mission statements, resource documents, and work on frameworks/standards for responsible genomic data sharing (e.g., their "Framework for Responsible Sharing of Genomic and Health-Related Data"). While a specific blog link from the prompt was general, GA4GH's role is central to these discussions.
+```


### PR DESCRIPTION
This commit introduces a new markdown file, `genomic_privacy_concerns.md`.

The chapter discusses privacy concerns related to specific genome datasets and diseases, focusing on the factors that cause these sensitivities. It is written in an expressive, high signal-to-noise ratio style, similar to a venture capital blog article (e.g., Sequoia VC, a16z).

Key elements include:
- Analysis of factors amplifying privacy risks (e.g., rare variants, high penetrance, stigma, population specificity).
- Spotlight on high-risk disease categories (hereditary cancers, rare monogenic disorders, neurodegenerative diseases, mental health disorders, pharmacogenomic variants, ethnic-specific disorders).
- A summary table detailing diseases, sensitivity reasons, and privacy needs.
- Discussion of privacy-enhancing strategies.
- Integration of research and references to support the discussion, including concepts from GINA, HIPAA, and recent data breach examples.